### PR TITLE
It’s now possible to exclude transportation types from the list of shown departures.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MMM-PublicTransportHafas
+
 MMM-PublicTransportHafas is a module for the MagicMirror project by Michael Teeuw.
 
 [![Maintainability](https://api.codeclimate.com/v1/badges/2742abc792b88536f6e2/maintainability)](https://codeclimate.com/github/raywo/MMM-PublicTransportHafas/maintainability)

--- a/css/leipzig-lines.css
+++ b/css/leipzig-lines.css
@@ -8,39 +8,39 @@
 
 
 .s1, .s2, .s3, .s4, .s5, .s5x, .s6 {
-  color: white;
   background-color: #1E944B;
-  width: 2em;
   border-radius: 1.25rem;
+  color: white;
+  width: 2em;
 }
 
 .str1, .str3, .str3e {
-  color: white;
   background-color: #5EB246;
+  color: white;
   width: 1em;
 }
 
 .str2, .str8, .str9 {
-  color: black;
   background-color: #F8C623;
+  color: black;
   width: 1em;
 }
 
 .str14 {
-  color: black;
   background-color: #00A8DB;
+  color: black;
   width: 1em;
 }
 
 .str4, .str7, .str12, .str15 {
-  color: white;
   background-color: #174489;
+  color: white;
   width: 1em;
 }
 
 .str10, .str11, .str16, .str51, .str56 {
-  color: white;
   background-color: #D8232A;
+  color: white;
   width: 1em;
 }
 
@@ -48,10 +48,10 @@
 .bus70, .bus72, .bus73, .bus73e, .bus74, .bus74e,
 .bus80, .bus81, .bus82, .bus89,
 .bus90 {
-  color: white;
   background-color: #912A7D;
-  width: 1em;
   border-radius: 1em;
+  color: white;
+  width: 1em;
 }
 
 .bus61, .bus63,
@@ -67,29 +67,29 @@
 .bus412,
 .bus645, .bus690, .bus691,
 .bus724, .bus743 {
-  color: white;
   background-color: #A3A3A2;
-  width: 1em;
   border-radius: 40px;
+  color: white;
+  width: 1em;
 }
 
 .busn1, .busn1e, .busn5, .busn5e, .busn8, .busn8e {
-  color: #164585;
   background-color: #EE9F2E;
-  width: 1em;
   border-radius: 40px;
+  color: #164585;
+  width: 1em;
 }
 
 .busn2, .busn2e, .busn7, .busn7e {
-  color: #164585;
   background-color: #FBDE89;
-  width: 1em;
   border-radius: 40px;
+  color: #164585;
+  width: 1em;
 }
 
 .busn3, .busn3e, .busn4, .busn4e, .busn6, .busn6e, .busn9, .busn9e {
-  color: #164585;
   background-color: #FCD120;
-  width: 1em;
   border-radius: 40px;
+  color: #164585;
+  width: 1em;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -8,9 +8,9 @@ them from the rest of the interface.
 }
 
 .pthTable {
-  display: table;
   border-collapse: collapse;
   border-spacing: 1px;
+  display: table;
 }
 
 .pthTable > thead {
@@ -22,9 +22,9 @@ them from the rest of the interface.
 }
 
 .pthRulerCell {
-  line-height: 0;
   border-spacing: 10px;
   border-bottom: 1px dotted #666;
+  line-height: 0;
 }
 
 .pthTextRight {
@@ -37,10 +37,10 @@ them from the rest of the interface.
 }
 
 .pthDirectionCell {
+  max-width: 24ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 24ch;
 }
 
 .pthHasDelay {
@@ -52,17 +52,17 @@ them from the rest of the interface.
 }
 
 .pthMarquee {
-  text-align: left;
   box-sizing: border-box;
   margin: 0 auto;
-  white-space: nowrap;
   overflow: hidden;
+  text-align: left;
+  white-space: nowrap;
 }
 
 .pthMarquee span {
+  animation: pthMarquee 3s linear infinite alternate;
   display: inline-block;
   white-space: nowrap;
-  animation: pthMarquee 3s linear infinite alternate;
 }
 
 @keyframes pthMarquee {
@@ -77,42 +77,42 @@ them from the rest of the interface.
 
 /* Styles for line symbols. */
 .pthSign {
+  background-color: #333333;
+  color: #666666;
+
   font-size: 0.9em;
   font-weight: bold;
-  text-align: center;
-  position: relative;
   margin-top: 0.1rem;
   margin-bottom: 0.1rem;
   margin-right: 0.5rem;
   padding-left: 5px;
   padding-right: 5px;
-
-  color: #666666;
-  background-color: #333333
+  position: relative;
+  text-align: center;
 }
 
 .pthBWLineSign {
-  color: #666666;
   background-color: #333333;
+  color: #666666;
 }
 
 /* Standards for Deutsche Bahn products. */
 .pthDbStandard {
+  border-radius: 5px;
   font-size: 0.8em;
   line-height: 1.4em;
-  border-radius: 5px;
 }
 
 .ice, .ic {
-  color: #F01414;
   background-color: white;
   border-bottom: 4px #F01414 solid;
+  color: #F01414;
 }
 
 .rb, .re {
-  color: white;
   background-color: #F01414;
   border: 0.5px white solid;
+  color: white;
 }
 
 .ice:before {


### PR DESCRIPTION
It’s now possible to exclude transportation types from the list of shown departures.
Fixed some css code styling problems.
PTHAFAS-8 #done